### PR TITLE
infra: add docker-compose.yml and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# PostgreSQL — used by docker-compose.yml and the Go API
+POSTGRES_DB=
+POSTGRES_USER=
+POSTGRES_PASSWORD=
+
+# Connection string consumed by the Go API (config/config.go)
+DATABASE_URL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    ports:
+      - "5433:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-coffee_journal}
+      POSTGRES_USER: ${POSTGRES_USER:-coffee}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-coffee}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-coffee} -d ${POSTGRES_DB:-coffee_journal}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## What changed
- Add `docker-compose.yml` — PostgreSQL 16 on host port 5433 with named volume for data persistence
- Add `.env.example` — empty-value template documenting required env vars for local dev

## Issues closed
Closes #4

## How to verify
- [x] `docker compose up -d` starts a healthy `db` container
- [x] `docker compose port db 5432` returns `0.0.0.0:5433`
- [x] `docker volume ls` shows `coffee-journal_postgres_data`
- [x] Data persists after `docker compose down && docker compose up -d`
- [ ] `.env.example` is committed; `.env` is gitignored