### PR TITLE
chore: expand .env.example with all required vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,23 @@
-# PostgreSQL — used by docker-compose.yml and the Go API
+# ── PostgreSQL (docker-compose.yml + Go API) ─────────────────────────────────
 POSTGRES_DB=
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 
-# Connection string consumed by the Go API (config/config.go)
+# Full connection string consumed by the Go API (config/config.go)
 DATABASE_URL=
+
+# ── Go API ────────────────────────────────────────────────────────────────────
+API_PORT=8080
+
+# ── Cloudflare R2 (photo uploads) ────────────────────────────────────────────
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+
+# ── Next.js ───────────────────────────────────────────────────────────────────
+# URL of the Go API — used by server components (SSR fetches)
+API_URL=http://localhost:8080
+
+# ── Auth (deferred — Phase 8) ─────────────────────────────────────────────────
+JWT_SECRET=


### PR DESCRIPTION
## What changed
- Expand `.env.example` with all env vars required by the full stack, grouped by service
- Also update local `.env` (gitignored) with dev defaults for the new vars

## Issues closed
Closes #5

## How to verify
- [ ] `.env.example` contains vars for PostgreSQL, Go API, Cloudflare R2, Next.js, and Auth
- [ ] R2 and JWT vars are empty (no safe local defaults)
- [ ] `API_PORT` defaults to `8080`, `API_URL` defaults to `http://localhost:8080`
- [ ] `.env` remains gitignored