### PR TITLE
chore: add Go binaries and air tmp dir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,22 @@
 .env.production
 # .env.example is intentionally NOT ignored (committed as a template)
 
+# ─── Go (api/) ───────────────────────────────────────────────────────────────
+# Compiled binaries
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+api/bin/
+
+# Test & coverage artifacts
+*.test
+*.out
+
+# air hot-reload tmp dir
+api/tmp/
+
 # ─── Next.js (web/) ──────────────────────────────────────────────────────────
 .next/
 node_modules/


### PR DESCRIPTION
## What changed
- Add Go section: compiled binaries (`*.exe`, `*.dll`, `*.so`, `*.dylib`, `api/bin/`)
- Add test/coverage artifacts (`*.test`, `*.out`)
- Add `api/tmp/` — air's hot-reload build directory

## Issues closed
Closes #6

## Note
`api/` doesn't exist yet — these entries are preemptive. Verification against actual Go build output will be possible once Phase 2 scaffolds the backend.