### PR TITLE
feat: Bean domain entity — value objects, entity, and repository interface (#37)

### DIFF
--- a/api/domain/altitude.go
+++ b/api/domain/altitude.go
@@ -1,0 +1,30 @@
+package domain
+
+import "fmt"
+
+type Altitude struct {
+	min int
+	max int
+}
+
+func NewAltitude(min, max int) (Altitude, error) {
+	if min < 0 {
+		return Altitude{}, fmt.Errorf("min altitude must be >= 0: %d", min)
+	}
+	if max < 0 {
+		return Altitude{}, fmt.Errorf("max altitude must be >= 0: %d", max)
+	}
+	if min > max {
+		return Altitude{}, fmt.Errorf("min altitude must be <= max: %d > %d", min, max)
+	}
+	return Altitude{min: min, max: max}, nil
+}
+
+func (a Altitude) Min() int {
+	return a.min
+}
+
+func (a Altitude) Max() int {
+	return a.max
+}
+

--- a/api/domain/altitude_test.go
+++ b/api/domain/altitude_test.go
@@ -1,0 +1,61 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAltitude_ValidValues(t *testing.T) {
+	tests := []struct{
+		name string
+		min int
+		max int
+	}{
+		{"valid range", 1200, 1800},
+		{"same value", 1500, 1500},
+		{"zero values", 0, 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := domain.NewAltitude(tt.min, tt.max)
+			assert.NoError(t, err)
+		})
+	}
+
+}
+
+func TestNewAltitude_InvalidValue(t *testing.T) {
+	tests := []struct{
+		name string
+		min int
+		max int
+	}{
+		{"negative min", -100, 100},
+		{"negative max", 100, -100},
+		{"min greater than max", 2000, 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := domain.NewAltitude(tt.min, tt.max)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestAltitude_Equality(t *testing.T) {
+	a, _ := domain.NewAltitude(1200, 1800)
+	b, _ := domain.NewAltitude(1200, 1800)
+	assert.Equal(t, a, b)
+}
+
+func TestAltitude_Getters(t *testing.T){
+	alt, err := domain.NewAltitude(1200, 1800)
+	require.NoError(t, err)
+	assert.Equal(t, 1200, alt.Min())
+	assert.Equal(t, 1800, alt.Max())
+}

--- a/api/domain/bean.go
+++ b/api/domain/bean.go
@@ -1,0 +1,76 @@
+package domain
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Bean struct {
+	id uuid.UUID
+	userID uuid.UUID
+	name string
+	roaster string
+	origin string
+	roastLevel RoastLevel
+	process *Process
+	altitude *Altitude
+	harvestSeason *string
+	packagePhotoURL *string
+	isPublic bool
+	createdAt time.Time
+	updatedAt time.Time
+	deletedAt *time.Time
+}
+
+func NewBean(
+	userID uuid.UUID,
+	name string,
+	roaster string,
+	origin string,
+	roastLevel RoastLevel,
+) (*Bean, error) {
+if userID == uuid.Nil {
+	return nil, fmt.Errorf("userID is required")
+}
+
+if name == "" {
+	return nil, fmt.Errorf("name is required")
+}
+
+if roaster == "" {
+	return nil, fmt.Errorf("roaster is required")
+}
+
+if origin == "" {
+	return nil, fmt.Errorf("origin is required")
+}
+
+return &Bean{
+	id: uuid.New(),
+	userID: userID,
+	name: name,
+	roaster: roaster,
+	origin: origin,
+	roastLevel: roastLevel,
+	createdAt: time.Now(),
+	updatedAt: time.Now(),
+	deletedAt: nil,
+}, nil
+}
+
+func (b *Bean) ID() uuid.UUID            { return b.id }
+func (b *Bean) UserID() uuid.UUID        { return b.userID }
+func (b *Bean) Name() string             { return b.name }
+func (b *Bean) Roaster() string          { return b.roaster }
+func (b *Bean) Origin() string           { return b.origin }
+func (b *Bean) RoastLevel() RoastLevel   { return b.roastLevel }
+func (b *Bean) Process() *Process        { return b.process }
+func (b *Bean) Altitude() *Altitude      { return b.altitude }
+func (b *Bean) HarvestSeason() *string   { return b.harvestSeason }
+func (b *Bean) PackagePhotoURL() *string { return b.packagePhotoURL }
+func (b *Bean) IsPublic() bool           { return b.isPublic }
+func (b *Bean) CreatedAt() time.Time     { return b.createdAt }
+func (b *Bean) UpdatedAt() time.Time     { return b.updatedAt }
+func (b *Bean) DeletedAt() *time.Time    { return b.deletedAt }

--- a/api/domain/bean.go
+++ b/api/domain/bean.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -74,3 +75,11 @@ func (b *Bean) IsPublic() bool           { return b.isPublic }
 func (b *Bean) CreatedAt() time.Time     { return b.createdAt }
 func (b *Bean) UpdatedAt() time.Time     { return b.updatedAt }
 func (b *Bean) DeletedAt() *time.Time    { return b.deletedAt }
+
+type BeanRepository interface {
+	Create(ctx context.Context, bean *Bean) error
+	GetByID(ctx context.Context, id uuid.UUID) (*Bean, error)
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]*Bean, error)
+	Update(ctx context.Context, bean *Bean) error
+	SoftDelete(ctx context.Context, id uuid.UUID) error
+}

--- a/api/domain/process.go
+++ b/api/domain/process.go
@@ -1,0 +1,25 @@
+package domain
+
+import "fmt"
+
+
+type Process string
+
+const (
+	ProcessWashed Process = "Washed"
+	ProcessNatural Process = "Natural"
+	ProcessHoney Process = "Honey"
+)
+
+func NewProcess(s string) (Process, error) {
+	switch Process(s) {
+		case ProcessWashed, ProcessNatural, ProcessHoney:
+			return Process(s), nil
+		default:
+			return "", fmt.Errorf("invalid process %q: must be Washed, Natural, or Honey", s)
+	}
+}
+
+func (p Process) String() string {
+	return string(p)
+}

--- a/api/domain/process_test.go
+++ b/api/domain/process_test.go
@@ -1,0 +1,52 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewProcess_ValidValues(t *testing.T){
+	tests := []struct{
+		input string
+		want string
+	}{
+		{"Washed", "Washed"},
+		{"Natural", "Natural"},
+		{"Honey", "Honey"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T){
+			process, err := domain.NewProcess(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, process.String())
+		})
+	}
+}
+
+func TestNewProcess_InvalidValue(t *testing.T) {
+	tests := []struct{
+		name string
+		input string
+	}{
+		{"empty string", ""},
+		{"unknown value", "Extra Washed"},
+		{"lowercase", "washed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := domain.NewProcess(tt.input)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestProcess_Equality(t *testing.T) {
+	a,  _ := domain.NewProcess("Washed")
+	b,  _ := domain.NewProcess("Washed")
+	assert.Equal(t, a, b)
+}

--- a/api/domain/roast_level.go
+++ b/api/domain/roast_level.go
@@ -1,0 +1,28 @@
+package domain
+
+import "fmt"
+
+// RoastLevel is a value object representing coffee roast intensity.
+// It has no identity — two RoastLevels with the same value are equal.
+type RoastLevel string
+
+const (
+	RoastLight  RoastLevel = "Light"
+	RoastMedium RoastLevel = "Medium"
+	RoastDark   RoastLevel = "Dark"
+)
+
+// NewRoastLevel validates and creates a RoastLevel.
+// This is the only way to create one — enforcing validity at birth.
+func NewRoastLevel(s string) (RoastLevel, error) {
+	switch RoastLevel(s) {
+	case RoastLight, RoastMedium, RoastDark:
+		return RoastLevel(s), nil
+	default:
+		return "", fmt.Errorf("invalid roast level %q: must be Light, Medium, or Dark", s)
+	}
+}
+
+func (r RoastLevel) String() string {
+	return string(r)
+}

--- a/api/domain/roast_level_test.go
+++ b/api/domain/roast_level_test.go
@@ -1,0 +1,56 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRoastLevel_ValidValues(t *testing.T) {
+	// Table-driven test — a Go convention for testing multiple inputs
+	// against the same logic. Each row is one scenario.
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Light", "Light"},
+		{"Medium", "Medium"},
+		{"Dark", "Dark"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			rl, err := domain.NewRoastLevel(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, rl.String())
+		})
+	}
+}
+
+func TestNewRoastLevel_InvalidValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"unknown value", "Extra Dark"},
+		{"lowercase", "light"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := domain.NewRoastLevel(tt.input)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestRoastLevel_Equality(t *testing.T) {
+	// Value object property: two objects with the same value ARE equal.
+	// No identity — just the value matters.
+	a, _ := domain.NewRoastLevel("Light")
+	b, _ := domain.NewRoastLevel("Light")
+	assert.Equal(t, a, b)
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/golang-migrate/migrate/v4 v4.19.1 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -7,6 +7,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
 github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjYXycRz/g5+RWDuYgPrE=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa h1:s+4MhCQ6YrzisK6hFJUX53drDT4UsSW3DEhKn0ifuHw=
 github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=


### PR DESCRIPTION
## Summary

- Add `RoastLevel` and `Process` value objects with validation and string parsing
- Add `Altitude` composite value object (min/max meters with range validation)
- Add `Bean` entity with `NewBean` factory, private fields, and typed getters
- Add `BeanRepository` interface (`Create`, `GetByID`, `ListByUser`, `Update`, `SoftDelete`)

Closes #37

## Test plan

- [ ] `go test ./domain/...` passes — value object tests cover valid inputs, invalid inputs, and edge cases
- [ ] `go build ./...` compiles clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)