### PR TITLE
feat: User entity, OAuthAccount struct, and UserRepository interface (#36)

### DIFF
--- a/api/domain/user.go
+++ b/api/domain/user.go
@@ -1,0 +1,66 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OAuthAccount is a value object representing a linked OAuth provider account.
+// Fields are exported because it is passed across layers as plain data.
+type OAuthAccount struct {
+	Provider       string
+	ProviderUserID string
+}
+
+// User is the aggregate root representing an application user.
+// All fields are private; access via getters only.
+type User struct {
+	id           uuid.UUID
+	email        string
+	passwordHash *string
+	name         string
+	createdAt    time.Time
+	updatedAt    time.Time
+	deletedAt    *time.Time
+}
+
+// NewUser creates a validated User with a new UUID and current timestamps.
+// passwordHash is always nil at creation — set separately for password-based auth.
+func NewUser(email, name string) (*User, error) {
+	if email == "" {
+		return nil, fmt.Errorf("email is required")
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("name is required")
+	}
+
+	return &User{
+		id:           uuid.New(),
+		email:        email,
+		passwordHash: nil,
+		name:         name,
+		createdAt:    time.Now(),
+		updatedAt:    time.Now(),
+		deletedAt:    nil,
+	}, nil
+}
+
+func (u *User) ID() uuid.UUID           { return u.id }
+func (u *User) Email() string           { return u.email }
+func (u *User) PasswordHash() *string   { return u.passwordHash }
+func (u *User) Name() string            { return u.name }
+func (u *User) CreatedAt() time.Time    { return u.createdAt }
+func (u *User) UpdatedAt() time.Time    { return u.updatedAt }
+func (u *User) DeletedAt() *time.Time   { return u.deletedAt }
+
+// UserRepository defines the persistence contract for User aggregates.
+type UserRepository interface {
+	Create(ctx context.Context, user *User) error
+	GetByID(ctx context.Context, id uuid.UUID) (*User, error)
+	GetByEmail(ctx context.Context, email string) (*User, error)
+	SoftDelete(ctx context.Context, id uuid.UUID) error
+}

--- a/api/domain/user_test.go
+++ b/api/domain/user_test.go
@@ -1,0 +1,36 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewUser_ValidInput(t *testing.T) {
+	email := "test@example.com"
+	name := "Yuto"
+
+	u, err := domain.NewUser(email, name)
+	require.NoError(t, err)
+	require.NotNil(t, u)
+
+	assert.Equal(t, email, u.Email())
+	assert.Equal(t, name, u.Name())
+	assert.NotEqual(t, [16]byte{}, u.ID()) // UUID is non-zero
+	assert.Nil(t, u.PasswordHash())
+	assert.Nil(t, u.DeletedAt())
+	assert.False(t, u.CreatedAt().IsZero())
+	assert.False(t, u.UpdatedAt().IsZero())
+}
+
+func TestNewUser_EmptyEmail(t *testing.T) {
+	_, err := domain.NewUser("", "Yuto")
+	assert.Error(t, err)
+}
+
+func TestNewUser_EmptyName(t *testing.T) {
+	_, err := domain.NewUser("test@example.com", "")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Add `OAuthAccount` value struct with exported fields (`Provider`, `ProviderUserID`)
- Add `User` entity with private fields, `NewUser(email, name string)` factory, and typed getters
- Add `UserRepository` interface (`Create`, `GetByID`, `GetByEmail`, `SoftDelete`)

Closes #36

## Test plan

- [ ] `go test ./domain/...` passes — valid input, empty email, empty name
- [ ] `go build ./...` compiles clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)