### PR TITLE
feat: Tasting entity, Aftertaste value object, and TastingRepository interface (#38)

### DIFF
--- a/api/domain/aftertaste.go
+++ b/api/domain/aftertaste.go
@@ -1,0 +1,28 @@
+package domain
+
+import "fmt"
+
+// Aftertaste is a value object representing the lingering quality of a coffee's finish.
+// It has no identity — two Aftertastes with the same value are equal.
+type Aftertaste string
+
+const (
+	AftertasteShort    Aftertaste = "Short"
+	AftertasteClean    Aftertaste = "Clean"
+	AftertasteLingering Aftertaste = "Lingering"
+)
+
+// ParseAftertaste validates and creates an Aftertaste from a string.
+// This is the only way to create one — enforcing validity at birth.
+func ParseAftertaste(s string) (Aftertaste, error) {
+	switch Aftertaste(s) {
+	case AftertasteShort, AftertasteClean, AftertasteLingering:
+		return Aftertaste(s), nil
+	default:
+		return "", fmt.Errorf("invalid aftertaste %q: must be Short, Clean, or Lingering", s)
+	}
+}
+
+func (a Aftertaste) String() string {
+	return string(a)
+}

--- a/api/domain/aftertaste_test.go
+++ b/api/domain/aftertaste_test.go
@@ -1,0 +1,60 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAftertaste_ValidValues(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Short", "Short"},
+		{"Clean", "Clean"},
+		{"Lingering", "Lingering"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			a, err := domain.ParseAftertaste(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, a.String())
+		})
+	}
+}
+
+func TestParseAftertaste_InvalidValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty string", ""},
+		{"unknown value", "Bitter"},
+		{"lowercase", "short"},
+		{"mixed case", "SHORT"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := domain.ParseAftertaste(tt.input)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestAftertaste_String(t *testing.T) {
+	assert.Equal(t, "Short", domain.AftertasteShort.String())
+	assert.Equal(t, "Clean", domain.AftertasteClean.String())
+	assert.Equal(t, "Lingering", domain.AftertasteLingering.String())
+}
+
+func TestAftertaste_Equality(t *testing.T) {
+	// Value object property: two objects with the same value ARE equal.
+	a, _ := domain.ParseAftertaste("Clean")
+	b, _ := domain.ParseAftertaste("Clean")
+	assert.Equal(t, a, b)
+}

--- a/api/domain/tasting.go
+++ b/api/domain/tasting.go
@@ -1,0 +1,161 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Tasting is the root entity representing a single evaluation session for a coffee bean.
+// All fields are private; access is exclusively through typed getters.
+type Tasting struct {
+	id         uuid.UUID
+	userID     uuid.UUID
+	beanID     uuid.UUID
+	flavorTags []string
+	brewMethod string
+	grindSize  string
+	acidity    int
+	aroma      int
+	body       int
+	sweetness  *int
+	overall    int
+	aftertaste Aftertaste
+	noteText   *string
+	createdAt  time.Time
+	updatedAt  time.Time
+	deletedAt  *time.Time
+}
+
+// NewTasting creates and validates a new Tasting entity.
+// Optional fields sweetness and noteText must be set separately via SetSweetness / SetNoteText.
+func NewTasting(
+	userID uuid.UUID,
+	beanID uuid.UUID,
+	flavorTags []string,
+	brewMethod string,
+	grindSize string,
+	acidity int,
+	aroma int,
+	body int,
+	overall int,
+	aftertaste Aftertaste,
+) (*Tasting, error) {
+	if userID == uuid.Nil {
+		return nil, fmt.Errorf("userID is required")
+	}
+
+	if beanID == uuid.Nil {
+		return nil, fmt.Errorf("beanID is required")
+	}
+
+	if brewMethod == "" {
+		return nil, fmt.Errorf("brewMethod is required")
+	}
+
+	if grindSize == "" {
+		return nil, fmt.Errorf("grindSize is required")
+	}
+
+	if err := validateScore("acidity", acidity); err != nil {
+		return nil, err
+	}
+
+	if err := validateScore("aroma", aroma); err != nil {
+		return nil, err
+	}
+
+	if err := validateScore("body", body); err != nil {
+		return nil, err
+	}
+
+	if err := validateScore("overall", overall); err != nil {
+		return nil, err
+	}
+
+	// Ensure flavorTags is never nil — an empty slice is the canonical zero value.
+	if flavorTags == nil {
+		flavorTags = []string{}
+	}
+
+	now := time.Now()
+	return &Tasting{
+		id:         uuid.New(),
+		userID:     userID,
+		beanID:     beanID,
+		flavorTags: flavorTags,
+		brewMethod: brewMethod,
+		grindSize:  grindSize,
+		acidity:    acidity,
+		aroma:      aroma,
+		body:       body,
+		overall:    overall,
+		aftertaste: aftertaste,
+		createdAt:  now,
+		updatedAt:  now,
+		deletedAt:  nil,
+	}, nil
+}
+
+// validateScore checks that a score is in the valid 1–5 range.
+func validateScore(field string, value int) error {
+	if value < 1 || value > 5 {
+		return fmt.Errorf("%s must be between 1 and 5, got %d", field, value)
+	}
+	return nil
+}
+
+// Getters — the only way to read Tasting state from outside the domain package.
+
+func (t *Tasting) ID() uuid.UUID          { return t.id }
+func (t *Tasting) UserID() uuid.UUID      { return t.userID }
+func (t *Tasting) BeanID() uuid.UUID      { return t.beanID }
+func (t *Tasting) FlavorTags() []string   { return t.flavorTags }
+func (t *Tasting) BrewMethod() string     { return t.brewMethod }
+func (t *Tasting) GrindSize() string      { return t.grindSize }
+func (t *Tasting) Acidity() int           { return t.acidity }
+func (t *Tasting) Aroma() int             { return t.aroma }
+func (t *Tasting) Body() int              { return t.body }
+func (t *Tasting) Sweetness() *int        { return t.sweetness }
+func (t *Tasting) Overall() int           { return t.overall }
+func (t *Tasting) Aftertaste() Aftertaste { return t.aftertaste }
+func (t *Tasting) NoteText() *string      { return t.noteText }
+func (t *Tasting) CreatedAt() time.Time   { return t.createdAt }
+func (t *Tasting) UpdatedAt() time.Time   { return t.updatedAt }
+func (t *Tasting) DeletedAt() *time.Time  { return t.deletedAt }
+
+// Setters for optional fields.
+
+// SetSweetness sets the nullable sweetness score.
+// Pass a pointer to an int (1–5), or nil to clear it.
+func (t *Tasting) SetSweetness(v *int) error {
+	if v != nil {
+		if err := validateScore("sweetness", *v); err != nil {
+			return err
+		}
+	}
+	t.sweetness = v
+	t.updatedAt = time.Now()
+	return nil
+}
+
+// SetNoteText sets the nullable free-form note text.
+func (t *Tasting) SetNoteText(v *string) {
+	t.noteText = v
+	t.updatedAt = time.Now()
+}
+
+// TastingRepository defines the persistence contract for Tasting aggregates.
+// All implementations must live in the repository layer — never in the domain.
+type TastingRepository interface {
+	Create(ctx context.Context, tasting *Tasting) error
+	GetByID(ctx context.Context, id uuid.UUID) (*Tasting, error)
+	ListByBean(ctx context.Context, beanID uuid.UUID) ([]*Tasting, error)
+	// Timeline returns tastings for a user ordered by created_at descending,
+	// using cursor-based pagination. Pass nil cursor for the first page.
+	Timeline(ctx context.Context, userID uuid.UUID, cursor *time.Time, limit int) ([]*Tasting, error)
+	Update(ctx context.Context, tasting *Tasting) error
+	SoftDelete(ctx context.Context, id uuid.UUID) error
+}

--- a/api/domain/tasting_test.go
+++ b/api/domain/tasting_test.go
@@ -1,0 +1,138 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/Ayut0/coffee-journal/api/domain"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// helpers used across tasting tests
+var (
+	validUserID = uuid.New()
+	validBeanID = uuid.New()
+)
+
+func validTastingArgs() (uuid.UUID, uuid.UUID, []string, string, string, int, int, int, int, domain.Aftertaste) {
+	return validUserID, validBeanID, []string{"chocolate", "citrus"}, "V60", "Medium", 3, 4, 3, 4, domain.AftertasteClean
+}
+
+func TestNewTasting_ValidInput(t *testing.T) {
+	userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	tasting, err := domain.NewTasting(userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, uuid.Nil, tasting.ID())
+	assert.Equal(t, userID, tasting.UserID())
+	assert.Equal(t, beanID, tasting.BeanID())
+	assert.Equal(t, tags, tasting.FlavorTags())
+	assert.Equal(t, brew, tasting.BrewMethod())
+	assert.Equal(t, grind, tasting.GrindSize())
+	assert.Equal(t, acidity, tasting.Acidity())
+	assert.Equal(t, aroma, tasting.Aroma())
+	assert.Equal(t, body, tasting.Body())
+	assert.Equal(t, overall, tasting.Overall())
+	assert.Equal(t, aftertaste, tasting.Aftertaste())
+	assert.Nil(t, tasting.Sweetness())
+	assert.Nil(t, tasting.NoteText())
+	assert.Nil(t, tasting.DeletedAt())
+	assert.False(t, tasting.CreatedAt().IsZero())
+	assert.False(t, tasting.UpdatedAt().IsZero())
+}
+
+func TestNewTasting_NilFlavorTagsBecomesEmptySlice(t *testing.T) {
+	userID, beanID, _, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	tasting, err := domain.NewTasting(userID, beanID, nil, brew, grind, acidity, aroma, body, overall, aftertaste)
+	require.NoError(t, err)
+	assert.NotNil(t, tasting.FlavorTags())
+	assert.Empty(t, tasting.FlavorTags())
+}
+
+func TestNewTasting_EmptyBrewMethod(t *testing.T) {
+	userID, beanID, tags, _, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	_, err := domain.NewTasting(userID, beanID, tags, "", grind, acidity, aroma, body, overall, aftertaste)
+	assert.Error(t, err)
+}
+
+func TestNewTasting_EmptyGrindSize(t *testing.T) {
+	userID, beanID, tags, brew, _, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	_, err := domain.NewTasting(userID, beanID, tags, brew, "", acidity, aroma, body, overall, aftertaste)
+	assert.Error(t, err)
+}
+
+func TestNewTasting_NilUserID(t *testing.T) {
+	_, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	_, err := domain.NewTasting(uuid.Nil, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	assert.Error(t, err)
+}
+
+func TestNewTasting_NilBeanID(t *testing.T) {
+	userID, _, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+
+	_, err := domain.NewTasting(userID, uuid.Nil, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	assert.Error(t, err)
+}
+
+func TestNewTasting_InvalidScore(t *testing.T) {
+	tests := []struct {
+		name             string
+		acidity, aroma, body, overall int
+	}{
+		{"acidity too low", 0, 3, 3, 3},
+		{"acidity too high", 6, 3, 3, 3},
+		{"aroma too low", 3, 0, 3, 3},
+		{"aroma too high", 3, 6, 3, 3},
+		{"body too low", 3, 3, 0, 3},
+		{"body too high", 3, 3, 6, 3},
+		{"overall too low", 3, 3, 3, 0},
+		{"overall too high", 3, 3, 3, 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID, beanID, tags, brew, grind, _, _, _, _, aftertaste := validTastingArgs()
+			_, err := domain.NewTasting(userID, beanID, tags, brew, grind, tt.acidity, tt.aroma, tt.body, tt.overall, aftertaste)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestTasting_SetSweetness(t *testing.T) {
+	userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+	tasting, err := domain.NewTasting(userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	require.NoError(t, err)
+
+	v := 4
+	err = tasting.SetSweetness(&v)
+	require.NoError(t, err)
+	require.NotNil(t, tasting.Sweetness())
+	assert.Equal(t, 4, *tasting.Sweetness())
+}
+
+func TestTasting_SetSweetness_Invalid(t *testing.T) {
+	userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+	tasting, err := domain.NewTasting(userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	require.NoError(t, err)
+
+	v := 6
+	err = tasting.SetSweetness(&v)
+	assert.Error(t, err)
+}
+
+func TestTasting_SetNoteText(t *testing.T) {
+	userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste := validTastingArgs()
+	tasting, err := domain.NewTasting(userID, beanID, tags, brew, grind, acidity, aroma, body, overall, aftertaste)
+	require.NoError(t, err)
+
+	note := "Bright and juicy with a long finish."
+	tasting.SetNoteText(&note)
+	require.NotNil(t, tasting.NoteText())
+	assert.Equal(t, note, *tasting.NoteText())
+}


### PR DESCRIPTION
## Summary

- Add `Aftertaste` value object (Short/Clean/Lingering) with `ParseAftertaste()` and `String()`, matching the `RoastLevel`/`Process` pattern
- Add `Tasting` entity with all private fields, `NewTasting` factory (validates required fields and 1–5 score range), typed getters, and `SetSweetness`/`SetNoteText` setters
- Nil `flavorTags` normalized to `[]string{}` in factory to satisfy "can be empty but not nil" invariant
- Add `TastingRepository` interface: `Create`, `GetByID`, `ListByBean`, `Timeline` (cursor-paginated by `created_at`), `Update`, `SoftDelete`

Closes #38

## Test plan

- [ ] `go test ./domain/...` passes — valid input, nil userID/beanID, empty brewMethod/grindSize, all invalid score combinations, setter validation
- [ ] `go build ./...` compiles clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)