### PR TITLE
feat: lib/api.ts base URL stub and types/index.ts placeholder (#21, #22)

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,0 +1,5 @@
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080";
+
+export function apiUrl(path: string): string {
+  return `${API_BASE}${path}`;
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,0 +1,2 @@
+// Types will be filled in as API endpoints are implemented (Phase 3+).
+export {};


### PR DESCRIPTION
## Summary

- Add `web/src/lib/api.ts` — base URL helper reading from `NEXT_PUBLIC_API_URL` (falls back to `http://localhost:8080`)
- Add `web/src/types/index.ts` — empty placeholder, to be filled in Phase 3+ as API shapes are defined

Closes #21
Closes #22

## Test plan

- [ ] `npm run build` in `web/` compiles without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)